### PR TITLE
esx:getSharedObject Deprecation

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -5,9 +5,7 @@ discord = {
 
 
 ----Gets ESX-----
-ESX = nil
-
-TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
+ESX = exports["es_extended"]:getSharedObject()
 
 
 


### PR DESCRIPTION
https://docs.esx-framework.org/tutorials/sharedevent/

removed warning message during startup